### PR TITLE
Add Fabric Mod Entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### Minecraft ###
+**/run

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 version = "${properties["net.teaclient.version"]}+${properties["net.teaclient.minecraft"]}-fabric"
 
+base {
+    archivesName.set(properties["net.teaclient.archives.base.name"].toString())
+}
+
 dependencies {
     minecraft(libs.minecraft)
     mappings(libs.yarn)
@@ -12,4 +16,10 @@ dependencies {
     modImplementation(libs.fabric.api)
     modImplementation(libs.fabric.language.kotlin)
     modImplementation(libs.fabric.loader)
+}
+
+tasks.processResources {
+    filesMatching("fabric.mod.json") {
+        expand(properties)
+    }
 }

--- a/fabric/src/main/kotlin/net/teaclient/TeaClient.kt
+++ b/fabric/src/main/kotlin/net/teaclient/TeaClient.kt
@@ -3,9 +3,40 @@ package net.teaclient
 import net.fabricmc.api.ModInitializer
 import org.apache.logging.log4j.LogManager
 
-class TeaClient : ModInitializer {
+/**
+ * The entrypoint to the Fabric mod. The fully-qualified name of this class
+ * (i.e. net.teaclient.TeaClientFabric) is to be registered as a `main` entrypoint
+ * in the `fabric.mod.json` Fabric mod manifest file.
+ *
+ * `main` entrypoint classes typically implement the [net.fabricmc.api.ModInitializer]
+ * interface and overrides the [net.fabricmc.api.ModInitializer.onInitialize] function to
+ * implement the initialization logic of the mod.
+ *
+ * @author HTGAzureX1212.
+ * @see net.fabricmc.api.ModInitializer
+ * @since 0.1.0
+ */
+class TeaClientFabric : ModInitializer {
+    /**
+     * A static instance of a Log4j [org.apache.logging.log4j.Logger] used by the client.
+     *
+     * Constructed by invoking the [org.apache.logging.log4j.LogManager.getLogger] function.
+     *
+     * @author HTGAzureX1212.
+     * @see org.apache.logging.log4j.Logger
+     * @since 0.1.0
+     */
     val logger = LogManager.getLogger("TeaClient")
 
+    /**
+     * The [onInitialize] function, overriding the [net.fabricmc.api.ModInitializer.onInitialize]
+     * function, runs the initialization logic for the client mod.
+     *
+     * @author HTGAzureX1212.
+     * @return nothing.
+     * @see net.fabricmc.api.ModInitializer.onInitialize
+     * @since 0.1.0
+     */
     override fun onInitialize() {
         logger.info("Hello world from TeaClient")
     }

--- a/fabric/src/main/kotlin/net/teaclient/TeaClient.kt
+++ b/fabric/src/main/kotlin/net/teaclient/TeaClient.kt
@@ -1,0 +1,12 @@
+package net.teaclient
+
+import net.fabricmc.api.ModInitializer
+import org.apache.logging.log4j.LogManager
+
+class TeaClient : ModInitializer {
+    val logger = LogManager.getLogger("TeaClient")
+
+    override fun onInitialize() {
+        logger.info("Hello world from TeaClient")
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -3,11 +3,16 @@
     "id": "teaclient",
     "version": "${version}",
     "name": "Tea Client",
+    "entrypoints": {
+        "main": [
+            "net.teaclient.TeaClient"
+        ]
+    },
     "depends": {
+        "fabric-api": "*",
         "fabric-language-kotlin": ">=1.10.0",
-        "fabric-loader": ">=0.15.0",
+        "fabricloader": ">=0.15.0",
         "minecraft": "~1.20.1",
-        "java": ">=17",
-        "fabric-api": "*"
+        "java": ">=17"
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -5,7 +5,7 @@
     "name": "Tea Client",
     "entrypoints": {
         "main": [
-            "net.teaclient.TeaClient"
+            "net.teaclient.TeaClientFabric"
         ]
     },
     "depends": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 # Use the official Kotlin programming style.
 kotlin.code.style=official
 
+# The name of the JAR file built.
+net.teaclient.archives.base.name=teaclient
 # The Minecraft version the client targets.
 net.teaclient.minecraft=1.20.1
 # The version of the client.


### PR DESCRIPTION
This pull request adds the `TeaClientFabric` Kotlin class and registers it as an entrypoint in the `fabric.mod.json` Fabric mod manifest file.

Apparently the name of the Fabric loader mod is `fabricloader`, not `fabric-loader`. This pull request also fixes that in the manifest file.